### PR TITLE
[FEAT] 회화 및 메시지 페이지네이션 적용

### DIFF
--- a/src/common/dto/cursor-pagination.dto.ts
+++ b/src/common/dto/cursor-pagination.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class CursorPaginationDto {
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @IsOptional()
+  @IsInt()
+  limit?: number = 10;
+}

--- a/src/common/dto/cursor-pagination.dto.ts
+++ b/src/common/dto/cursor-pagination.dto.ts
@@ -1,4 +1,5 @@
-import { IsInt, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class CursorPaginationDto {
   @IsOptional()
@@ -7,5 +8,7 @@ export class CursorPaginationDto {
 
   @IsOptional()
   @IsInt()
+  @Min(1)
+  @Max(20)
   limit?: number = 10;
 }

--- a/src/common/dto/paginated-response.dto.ts
+++ b/src/common/dto/paginated-response.dto.ts
@@ -1,0 +1,7 @@
+export class PaginatedResponseDto<T> {
+  data: T[];
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+}

--- a/src/common/utils/pagination.util.ts
+++ b/src/common/utils/pagination.util.ts
@@ -1,0 +1,30 @@
+import { BadRequestException } from '@nestjs/common';
+
+export function encodeCursor(id: number): string {
+  return Buffer.from(id.toString()).toString('base64');
+}
+
+export function decodeCursor(cursor: string): string {
+  const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
+  return decoded;
+}
+
+export function validateCursor(cursor: string) {
+  try {
+    const decodedCursor = decodeCursor(cursor);
+    const parsedCursor = JSON.parse(decodedCursor);
+    const id = parseInt(parsedCursor.id, 10);
+
+    if (isNaN(id) || id < 0) {
+      throw new Error('지원하지 않는 커서 포맷');
+    }
+
+    return id;
+  } catch (error) {
+    throw new BadRequestException('지원하지 않는 커서 포맷');
+  }
+}
+
+export function createEndCursor<T extends { id: number }>(entitiy: T[]) {
+  return encodeCursor(entitiy[entitiy.length - 1].id);
+}

--- a/src/common/utils/pagination.util.ts
+++ b/src/common/utils/pagination.util.ts
@@ -1,17 +1,17 @@
 import { BadRequestException } from '@nestjs/common';
 
-export function encodeCursor(id: number): string {
-  return Buffer.from(id.toString()).toString('base64');
+export function encodeCursorId(id: number): string {
+  return Buffer.from(JSON.stringify({ id })).toString('base64');
 }
 
-export function decodeCursor(cursor: string): string {
+export function decodeCursorId(cursor: string): string {
   const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
   return decoded;
 }
 
 export function validateCursor(cursor: string) {
   try {
-    const decodedCursor = decodeCursor(cursor);
+    const decodedCursor = decodeCursorId(cursor);
     const parsedCursor = JSON.parse(decodedCursor);
     const id = parseInt(parsedCursor.id, 10);
 
@@ -25,6 +25,6 @@ export function validateCursor(cursor: string) {
   }
 }
 
-export function createEndCursor<T extends { id: number }>(entitiy: T[]) {
-  return encodeCursor(entitiy[entitiy.length - 1].id);
+export function createEndCursorId<T extends { id: number }>(entitiy: T[]) {
+  return encodeCursorId(entitiy[entitiy.length - 1].id);
 }

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -9,6 +9,7 @@ import {
   UseInterceptors,
   ClassSerializerInterceptor,
   ParseIntPipe,
+  Query,
 } from '@nestjs/common';
 import { ConversationsService } from './conversations.service';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
@@ -17,6 +18,7 @@ import { CreateConversationDto } from './dto/create-conversation.dto';
 import { Roles } from 'src/auth/decorator/roles.decorator';
 import { Role } from 'src/users/entities/user.entity';
 import { AuthUser } from 'src/users/decorator/authUser.decorator';
+import { CursorPaginationDto } from 'src/common/dto/cursor-pagination.dto';
 
 @Controller('conversations')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -73,8 +75,16 @@ export class ConversationsController {
   getMessagesForConversation(
     @Param('id', ParseIntPipe) id: number,
     @AuthUser('id') userId: string,
+    @Query() cursorPaginationDto: CursorPaginationDto,
   ) {
-    return this.conversationsService.findUserConversationMessages(id, userId);
+    console.log(cursorPaginationDto);
+
+    return this.conversationsService.findUserConversationMessages(
+      id,
+      userId,
+      cursorPaginationDto.cursor,
+      cursorPaginationDto.limit,
+    );
   }
 
   @Post(':id/message')

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -36,10 +36,22 @@ export class ConversationsController {
     );
   }
 
-  @Get()
+  @Get('all')
   @Roles(Role.Admin)
   findAll() {
     return this.conversationsService.findAll();
+  }
+
+  @Get()
+  findUserConversations(
+    @AuthUser('id') userId: string,
+    @Query() cursorPaginationDto: CursorPaginationDto,
+  ) {
+    return this.conversationsService.findUserConversations(
+      userId,
+      cursorPaginationDto.cursor,
+      cursorPaginationDto.limit,
+    );
   }
 
   @Get(':id')
@@ -77,8 +89,6 @@ export class ConversationsController {
     @AuthUser('id') userId: string,
     @Query() cursorPaginationDto: CursorPaginationDto,
   ) {
-    console.log(cursorPaginationDto);
-
     return this.conversationsService.findUserConversationMessages(
       id,
       userId,

--- a/src/conversations/conversations.module.ts
+++ b/src/conversations/conversations.module.ts
@@ -8,7 +8,7 @@ import { AiModule } from 'src/ai/ai.module';
 import { Situation } from 'src/situations/entities/situation.entity';
 import { PromptModule } from 'src/ai/prompt/prompt.module';
 import { TypeOrmConversationRepository } from './repositories/typeorm-conversation.repository';
-import { TypeOrmMessageRepository } from './repositories/typeorm-message.repositoy';
+import { TypeOrmMessageRepository } from './repositories/typeorm-message.repository';
 
 @Module({
   imports: [

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -158,18 +158,25 @@ export class ConversationsService {
     return { data: res };
   }
 
-  async findUserConversationMessages(id: number, userId: string) {
-    const relations = ['messages'];
+  async findUserConversationMessages(
+    id: number,
+    userId: string,
+    cusor: string,
+    limit: number,
+  ) {
     const conversation = await this.conversationRepository.findOneByIdAndUserId(
       id,
       userId,
-      relations,
     );
 
     if (!conversation) {
       throw new ForbiddenException();
     }
 
-    return conversation.messages;
+    return await this.messagesRepository.findByConversationIdWithCursor(
+      id,
+      cusor,
+      limit,
+    );
   }
 }

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -172,7 +172,7 @@ export class ConversationsService {
   async findUserConversationMessages(
     id: number,
     userId: string,
-    cusor: string,
+    cursor: string,
     limit: number,
   ) {
     const conversation = await this.conversationRepository.findOneByIdAndUserId(
@@ -186,7 +186,7 @@ export class ConversationsService {
 
     return await this.messagesRepository.findByConversationIdWithCursor(
       id,
-      cusor,
+      cursor,
       limit,
     );
   }

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -56,6 +56,17 @@ export class ConversationsService {
     return await this.conversationRepository.findAll(relations);
   }
 
+  async findUserConversations(userId: string, cursor?: string, limit?: number) {
+    const conversations =
+      await this.conversationRepository.findByUserIdWithCursor(
+        userId,
+        cursor,
+        limit,
+      );
+
+    return conversations;
+  }
+
   async findUserConversation(id: number, userId: string) {
     const relations = ['situation', 'messages'];
     const conversation = await this.conversationRepository.findOneByIdAndUserId(

--- a/src/conversations/repositories/conversation.repository.interface.ts
+++ b/src/conversations/repositories/conversation.repository.interface.ts
@@ -1,3 +1,4 @@
+import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
 import { UpdateConversationDto } from '../dto/update-conversation.dto';
 import { Conversation } from '../entities/conversation.entity';
 
@@ -16,4 +17,9 @@ export interface IConversationRepository {
   ): Promise<Conversation>;
   update(id: number, updateData: UpdateConversationDto): Promise<void>;
   delete(id: number): Promise<void>;
+  findByUserIdWithCursor(
+    userId: string,
+    cursor?: string,
+    limit?: number,
+  ): Promise<PaginatedResponseDto<Conversation>>;
 }

--- a/src/conversations/repositories/message.repository.interface.ts
+++ b/src/conversations/repositories/message.repository.interface.ts
@@ -1,11 +1,16 @@
 import { FindManyOptions } from 'typeorm';
 import { Message } from '../entities/message.entity';
+import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
 
 export interface IMessageRepository {
   save(messageData: Partial<Message>): Promise<Message>;
-
   findByConversationId(
     conversationId: number,
     options: FindManyOptions,
   ): Promise<Message[]>;
+  findByConversationIdWithCursor(
+    conversationId: number,
+    cursor?: string,
+    limit?: number,
+  ): Promise<PaginatedResponseDto<Message>>;
 }

--- a/src/conversations/repositories/typeorm-conversation.repository.ts
+++ b/src/conversations/repositories/typeorm-conversation.repository.ts
@@ -6,8 +6,8 @@ import { UpdateConversationDto } from '../dto/update-conversation.dto';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
 import {
-  createEndCursor,
-  decodeCursor,
+  createEndCursorId,
+  decodeCursorId,
   validateCursor,
 } from 'src/common/utils/pagination.util';
 
@@ -50,7 +50,7 @@ export class TypeOrmConversationRepository implements IConversationRepository {
 
     if (cursor) {
       try {
-        const decodedCursor = decodeCursor(cursor);
+        const decodedCursor = decodeCursorId(cursor);
         const parsedCursor = JSON.stringify(decodedCursor);
         const cursorId = validateCursor(parsedCursor);
         qb.andWhere('conversation.id < :id', { id: cursorId });
@@ -68,7 +68,7 @@ export class TypeOrmConversationRepository implements IConversationRepository {
     }
 
     const endCursor =
-      conversations.length > 0 ? createEndCursor(conversations) : null;
+      conversations.length > 0 ? createEndCursorId(conversations) : null;
 
     return {
       data: conversations,

--- a/src/conversations/repositories/typeorm-conversation.repository.ts
+++ b/src/conversations/repositories/typeorm-conversation.repository.ts
@@ -50,9 +50,7 @@ export class TypeOrmConversationRepository implements IConversationRepository {
 
     if (cursor) {
       try {
-        const decodedCursor = decodeCursorId(cursor);
-        const parsedCursor = JSON.stringify(decodedCursor);
-        const cursorId = validateCursor(parsedCursor);
+        const cursorId = validateCursor(cursor);
         qb.andWhere('conversation.id < :id', { id: cursorId });
       } catch (error) {
         console.error(error);

--- a/src/conversations/repositories/typeorm-conversation.repository.ts
+++ b/src/conversations/repositories/typeorm-conversation.repository.ts
@@ -3,7 +3,13 @@ import { Conversation } from '../entities/conversation.entity';
 import { IConversationRepository } from './conversation.repository.interface';
 import { Repository } from 'typeorm';
 import { UpdateConversationDto } from '../dto/update-conversation.dto';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
+import {
+  createEndCursor,
+  decodeCursor,
+  validateCursor,
+} from 'src/common/utils/pagination.util';
 
 @Injectable()
 export class TypeOrmConversationRepository implements IConversationRepository {
@@ -11,6 +17,7 @@ export class TypeOrmConversationRepository implements IConversationRepository {
     @InjectRepository(Conversation)
     private readonly conversationRepository: Repository<Conversation>,
   ) {}
+
   async findOneById(
     id: number,
     relations?: string[],
@@ -29,6 +36,47 @@ export class TypeOrmConversationRepository implements IConversationRepository {
   }
   async findAll(relations?: string[]): Promise<Conversation[] | null> {
     return await this.conversationRepository.find({ relations });
+  }
+  async findByUserIdWithCursor(
+    userId: string,
+    cursor?: string,
+    limit?: number,
+  ): Promise<PaginatedResponseDto<Conversation>> {
+    const qb = this.conversationRepository
+      .createQueryBuilder('conversation')
+      .where('conversation.userId = :userId', { userId })
+      .orderBy('conversation.id', 'DESC')
+      .limit(limit + 1);
+
+    if (cursor) {
+      try {
+        const decodedCursor = decodeCursor(cursor);
+        const parsedCursor = JSON.stringify(decodedCursor);
+        const cursorId = validateCursor(parsedCursor);
+        qb.andWhere('conversation.id < :id', { id: cursorId });
+      } catch (error) {
+        console.error(error);
+        throw new BadRequestException('잘못된 커서 포맷');
+      }
+    }
+
+    const conversations = await qb.getMany();
+
+    const hasNextPage = conversations.length > limit;
+    if (hasNextPage) {
+      conversations.pop();
+    }
+
+    const endCursor =
+      conversations.length > 0 ? createEndCursor(conversations) : null;
+
+    return {
+      data: conversations,
+      pageInfo: {
+        hasNextPage,
+        endCursor,
+      },
+    };
   }
   async findOneByIdAndUserId(
     id: number,

--- a/src/conversations/repositories/typeorm-message.repository.ts
+++ b/src/conversations/repositories/typeorm-message.repository.ts
@@ -6,7 +6,6 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
 import {
   createEndCursorId,
-  decodeCursorId,
   validateCursor,
 } from 'src/common/utils/pagination.util';
 

--- a/src/conversations/repositories/typeorm-message.repository.ts
+++ b/src/conversations/repositories/typeorm-message.repository.ts
@@ -5,7 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
 import {
-  createEndCursor,
+  createEndCursorId,
   validateCursor,
 } from 'src/common/utils/pagination.util';
 
@@ -58,7 +58,7 @@ export class TypeOrmMessageRepository implements IMessageRepository {
       messages.pop();
     }
 
-    const endCursor = messages.length > 0 ? createEndCursor(messages) : null;
+    const endCursor = messages.length > 0 ? createEndCursorId(messages) : null;
 
     return {
       data: messages,

--- a/src/conversations/repositories/typeorm-message.repository.ts
+++ b/src/conversations/repositories/typeorm-message.repository.ts
@@ -2,7 +2,12 @@ import { FindManyOptions, Repository } from 'typeorm';
 import { Message } from '../entities/message.entity';
 import { IMessageRepository } from './message.repository.interface';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
+import {
+  createEndCursor,
+  validateCursor,
+} from 'src/common/utils/pagination.util';
 
 @Injectable()
 export class TypeOrmMessageRepository implements IMessageRepository {
@@ -13,6 +18,7 @@ export class TypeOrmMessageRepository implements IMessageRepository {
   async save(messageData: Partial<Message>): Promise<Message> {
     return await this.messageRepository.save(messageData);
   }
+
   async findByConversationId(
     conversationId: number,
     options: FindManyOptions<Message | null>,
@@ -22,5 +28,44 @@ export class TypeOrmMessageRepository implements IMessageRepository {
       ...restOptions,
       where: { conversation: { id: conversationId }, ...optionsWhere },
     });
+  }
+
+  async findByConversationIdWithCursor(
+    conversationId: number,
+    cursor?: string,
+    limit: number = 10,
+  ): Promise<PaginatedResponseDto<Message>> {
+    const qb = this.messageRepository
+      .createQueryBuilder('message')
+      .where('message.conversationId = :conversationId', { conversationId })
+      .orderBy('message.id', 'DESC')
+      .take(limit + 1);
+
+    if (cursor) {
+      try {
+        const cursorId = validateCursor(cursor);
+        qb.andWhere('message.id < :cursor', { cursor: cursorId });
+      } catch (error) {
+        console.error(error);
+        throw new BadRequestException();
+      }
+    }
+
+    const messages = await qb.getMany();
+
+    const hasNextPage = messages.length > limit;
+    if (hasNextPage) {
+      messages.pop();
+    }
+
+    const endCursor = messages.length > 0 ? createEndCursor(messages) : null;
+
+    return {
+      data: messages,
+      pageInfo: {
+        hasNextPage,
+        endCursor,
+      },
+    };
   }
 }

--- a/src/conversations/repositories/typeorm-message.repository.ts
+++ b/src/conversations/repositories/typeorm-message.repository.ts
@@ -6,6 +6,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
 import {
   createEndCursorId,
+  decodeCursorId,
   validateCursor,
 } from 'src/common/utils/pagination.util';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,13 @@ async function bootstrap() {
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('doc', app, documentFactory);
-  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+      whitelist: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ async function bootstrap() {
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('doc', app, documentFactory);
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
### ➕ 관련 이슈
#31 

### 🔎 주요 변경 사항
- conversation-repository와 message-repository에 커서기반 페이지네이션 적용
- 회화와 메시지 조회시 커서 반환

### 기타
- 응답 구조
```
{
    data: T[]
    pageInfo: {
        hasNext: boolean
        endCursor: string
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 사용자 대화 및 메시지 조회에 커서 기반 페이지네이션 기능이 도입되어, 대화 내역과 메시지를 페이지 단위로 효율적으로 확인할 수 있습니다.
  - 사용자 전용 대화 조회 엔드포인트가 추가되어, 본인과 관련된 대화를 손쉽게 접근할 수 있습니다.

- **개선사항**
  - 입력 데이터의 자동 타입 변환 기능이 강화되어, 데이터 검증 및 처리의 정확성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->