### PR TITLE
[Refactor]conversation, message 페이지네이션 공통로직 BaseRepository로 이전

### DIFF
--- a/src/common/repositories/base.repository.ts
+++ b/src/common/repositories/base.repository.ts
@@ -1,0 +1,58 @@
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import {
+  decodeCursor,
+  encodeCursorObj,
+  validateDateIdCursor,
+} from '../utils/pagination.util';
+
+export abstract class BaseRepository<
+  T extends { id: string | number; createdAt: Date },
+> {
+  constructor(protected readonly repository: Repository<T>) {}
+
+  protected createQueryBuilder(alias: string): SelectQueryBuilder<T> {
+    return this.repository.createQueryBuilder(alias);
+  }
+
+  protected async applyDateIdPagination(
+    qb: SelectQueryBuilder<T>,
+    cursor?: string,
+    limit: number = 10,
+    sortDirection: 'DESC' | 'ASC' = 'DESC',
+  ) {
+    qb.orderBy(`${qb.alias}.createdAt`, sortDirection)
+      .addOrderBy(`${qb.alias}.id`, sortDirection)
+      .take(limit + 1);
+
+    if (cursor) {
+      const decodedCursor = validateDateIdCursor(cursor);
+      const direction = sortDirection === 'DESC' ? '<' : '>';
+      qb.where(
+        `(${qb.alias}.id, ${qb.alias}.createdAt) ${direction} (:id, :createdAt)`,
+        decodedCursor,
+      );
+    }
+
+    const items = await qb.getMany();
+    const hasNextPage = items.length > limit;
+    if (hasNextPage) {
+      items.pop();
+    }
+
+    const endCursor =
+      items.length > 0 ? this.createEndCursor(items[items.length - 1]) : null;
+
+    return {
+      data: items,
+      pageInfo: {
+        hasNextPage,
+        endCursor,
+      },
+    };
+  }
+
+  private createEndCursor(item: T) {
+    const { id, createdAt } = item;
+    return encodeCursorObj({ id, createdAt });
+  }
+}

--- a/src/common/utils/pagination.util.ts
+++ b/src/common/utils/pagination.util.ts
@@ -4,14 +4,18 @@ export function encodeCursorId(id: number): string {
   return Buffer.from(JSON.stringify({ id })).toString('base64');
 }
 
-export function decodeCursorId(cursor: string): string {
+export function encodeCursorObj(obj: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(obj)).toString('base64');
+}
+
+export function decodeCursor(cursor: string): string {
   const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
   return decoded;
 }
 
-export function validateCursor(cursor: string) {
+export function validateCursorId(cursor: string) {
   try {
-    const decodedCursor = decodeCursorId(cursor);
+    const decodedCursor = decodeCursor(cursor);
     const parsedCursor = JSON.parse(decodedCursor);
     const id = parseInt(parsedCursor.id, 10);
 
@@ -25,6 +29,15 @@ export function validateCursor(cursor: string) {
   }
 }
 
-export function createEndCursorId<T extends { id: number }>(entitiy: T[]) {
-  return encodeCursorId(entitiy[entitiy.length - 1].id);
+export function validateDateIdCursor(cursor: string): {
+  id: string | number;
+  createdAt: Date;
+} {
+  try {
+    const decodedCursor = decodeCursor(cursor);
+    const { id, createdAt } = JSON.parse(decodedCursor);
+    return { id, createdAt };
+  } catch (error) {
+    throw new BadRequestException('지원하지 않는 커서 포맷');
+  }
 }

--- a/src/conversations/repositories/typeorm-conversation.repository.ts
+++ b/src/conversations/repositories/typeorm-conversation.repository.ts
@@ -5,18 +5,20 @@ import { Repository } from 'typeorm';
 import { UpdateConversationDto } from '../dto/update-conversation.dto';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
-import {
-  createEndCursorId,
-  decodeCursorId,
-  validateCursor,
-} from 'src/common/utils/pagination.util';
+import { validateCursorId } from 'src/common/utils/pagination.util';
+import { BaseRepository } from 'src/common/repositories/base.repository';
 
 @Injectable()
-export class TypeOrmConversationRepository implements IConversationRepository {
+export class TypeOrmConversationRepository
+  extends BaseRepository<Conversation>
+  implements IConversationRepository
+{
   constructor(
     @InjectRepository(Conversation)
     private readonly conversationRepository: Repository<Conversation>,
-  ) {}
+  ) {
+    super(conversationRepository);
+  }
 
   async findOneById(
     id: number,
@@ -44,37 +46,9 @@ export class TypeOrmConversationRepository implements IConversationRepository {
   ): Promise<PaginatedResponseDto<Conversation>> {
     const qb = this.conversationRepository
       .createQueryBuilder('conversation')
-      .where('conversation.userId = :userId', { userId })
-      .orderBy('conversation.id', 'DESC')
-      .limit(limit + 1);
+      .where('conversation.userId = :userId', { userId });
 
-    if (cursor) {
-      try {
-        const cursorId = validateCursor(cursor);
-        qb.andWhere('conversation.id < :id', { id: cursorId });
-      } catch (error) {
-        console.error(error);
-        throw new BadRequestException('잘못된 커서 포맷');
-      }
-    }
-
-    const conversations = await qb.getMany();
-
-    const hasNextPage = conversations.length > limit;
-    if (hasNextPage) {
-      conversations.pop();
-    }
-
-    const endCursor =
-      conversations.length > 0 ? createEndCursorId(conversations) : null;
-
-    return {
-      data: conversations,
-      pageInfo: {
-        hasNextPage,
-        endCursor,
-      },
-    };
+    return await this.applyDateIdPagination(qb, cursor, limit);
   }
   async findOneByIdAndUserId(
     id: number,

--- a/src/conversations/repositories/typeorm-message.repository.ts
+++ b/src/conversations/repositories/typeorm-message.repository.ts
@@ -4,17 +4,19 @@ import { IMessageRepository } from './message.repository.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginatedResponseDto } from 'src/common/dto/paginated-response.dto';
-import {
-  createEndCursorId,
-  validateCursor,
-} from 'src/common/utils/pagination.util';
+import { BaseRepository } from 'src/common/repositories/base.repository';
 
 @Injectable()
-export class TypeOrmMessageRepository implements IMessageRepository {
+export class TypeOrmMessageRepository
+  extends BaseRepository<Message>
+  implements IMessageRepository
+{
   constructor(
     @InjectRepository(Message)
     private readonly messageRepository: Repository<Message>,
-  ) {}
+  ) {
+    super(messageRepository);
+  }
   async save(messageData: Partial<Message>): Promise<Message> {
     return await this.messageRepository.save(messageData);
   }
@@ -35,37 +37,10 @@ export class TypeOrmMessageRepository implements IMessageRepository {
     cursor?: string,
     limit: number = 10,
   ): Promise<PaginatedResponseDto<Message>> {
-    const qb = this.messageRepository
-      .createQueryBuilder('message')
-      .where('message.conversationId = :conversationId', { conversationId })
-      .orderBy('message.id', 'DESC')
-      .take(limit + 1);
-
-    if (cursor) {
-      try {
-        const cursorId = validateCursor(cursor);
-        qb.andWhere('message.id < :cursor', { cursor: cursorId });
-      } catch (error) {
-        console.error(error);
-        throw new BadRequestException();
-      }
-    }
-
-    const messages = await qb.getMany();
-
-    const hasNextPage = messages.length > limit;
-    if (hasNextPage) {
-      messages.pop();
-    }
-
-    const endCursor = messages.length > 0 ? createEndCursorId(messages) : null;
-
-    return {
-      data: messages,
-      pageInfo: {
-        hasNextPage,
-        endCursor,
-      },
-    };
+    const qb = this.createQueryBuilder('message').where(
+      'message.conversationId = :conversationId',
+      { conversationId },
+    );
+    return await this.applyDateIdPagination(qb, cursor, limit);
   }
 }


### PR DESCRIPTION
### ➕ 관련 이슈
#31 
### 🔎 주요 변경 사항
- ConversationRepository, MessageRepository에 있던 페이지네이션 기능을 BaseRepository로 이전하고 상속 받아 사용하도록 변경햇습니다.
### 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 대화 및 메시지 목록 조회에서 커서 기반 페이지 네이션 기능이 강화되어, 보다 원활하고 정교한 결과 확인이 가능해졌습니다.
- **Refactor**
	- 데이터 조회 및 페이징 처리 로직이 통합, 단순화되어 시스템 안정성과 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->