### PR TITLE
[Fix] 페이지네이션 쿼리빌더 where절 덮어쓰기 문제  해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
       "bcrypt"
     ],
     "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@scarf/scarf",
       "bcrypt"
     ]
   }

--- a/src/common/repositories/base.repository.ts
+++ b/src/common/repositories/base.repository.ts
@@ -27,7 +27,7 @@ export abstract class BaseRepository<
     if (cursor) {
       const decodedCursor = validateDateIdCursor(cursor);
       const direction = sortDirection === 'DESC' ? '<' : '>';
-      qb.where(
+      qb.andWhere(
         `(${qb.alias}.id, ${qb.alias}.createdAt) ${direction} (:id, :createdAt)`,
         decodedCursor,
       );


### PR DESCRIPTION
### ➕ 관련 이슈
#48

### 🔎 주요 변경 사항
- 회화 메시지 조회 시, 기존 conversationId 조건이 커서 기반 페이지네이션의 where 절로 덮어쓰기되는 문제가 있었습니다.
- 이를 해결하기 위해 커서 조건을 where → andWhere로 수정하여 기존 조건을 유지하도록 변경했습니다.

### 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 빌드 과정 개선을 위해 추가 의존성이 구성에 포함되었습니다.
- **Bug Fixes**
	- 데이터 페이징 필터링 시 조건 결합 방식이 개선되어 보다 정확한 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->